### PR TITLE
chore(pi-hole_setup): don't set secondary upstream DNS by default

### DIFF
--- a/templates/etc/pihole/setupVars.conf.j2
+++ b/templates/etc/pihole/setupVars.conf.j2
@@ -1,6 +1,7 @@
 {% if pi_hole_webpasswd is defined %}
 WEBPASSWORD={{ pi_hole_webpasswd }}
 {% endif %}
+CACHE_SIZE={{ pi_hole_cache_size | default("10000") }}
 DNSMASQ_LISTENING={{ pi_hole_dnsmasq_listening | default("single") }}
 DNS_FQDN_REQUIRED={{ pi_hole_fqdn_required | default(false) | lower }}
 DNS_BOGUS_PRIV={{ pi_hole_bogus_priv | default(false) | lower }}
@@ -12,7 +13,9 @@ IPV4_ADDRESS={{ ansible_default_ipv4.address }}/24
 IPV6_ADDRESS={{ ansible_default_ipv6.address }}
 {% endif %}
 PIHOLE_DNS_1={{ pi_hole_dns_1 | default("8.8.8.8") }}#{{ pi_hole_dns_1_port | default("53") }}
-PIHOLE_DNS_2={{ pi_hole_dns_2 | default("8.8.4.4") }}#{{ pi_hole_dns_2_port | default("53") }}
+{% if pi_hole_dns_2 is defined and pi_hole_dns_2_port is defined %}
+PIHOLE_DNS_2={{ pi_hole_dns_2 }}#{{ pi_hole_dns_2_port | default("53") }}
+{% endif %}
 QUERY_LOGGING={{ pi_hole_query_logging | default(true) | lower }}
 INSTALL_WEB_SERVER={{ pi_hole_install_web_server | default(true) | lower }}
 INSTALL_WEB_INTERFACE={{ pi_hole_install_web_interface | default(true) | lower }}


### PR DESCRIPTION
## Why ?
Only set secondary upstream DNS if defined in vars

## How ?
* add conditionnal test for `PIHOLE_DNS_2` in template