### PR TITLE
pihole: Add local DNS records support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Add `pi-hole` variable for config. These vars can be omited
 * `pi_hole_rev_server_cidr` - (default: "") - `pi-hole` reverse cidr
 * `pi_hole_blocking_enabled` - (default: true) - enable `pi-hole` blocking
 
+## Define pi-hole local DNS configuration
+* `pi_hole_local_dns_records` - (default: "") - define `pi-hole` local DNS records. Expects a list of dictionnaries in which each items contains a key `ip` and `name`.
+
+Example:
+```yaml
+vars:
+  pi_hole_local_dns_records:
+    - name: db.lan
+      ip: 10.0.13.37
+    - name: web.lan
+      ip: 10.0.13.38
+```
+
 ## Define pi-hole FTL configuration
 
 Add `pi-hole-FTL` variable config. These vars can be omited

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,42 +1,14 @@
 ---
 galaxy_info:
-  author: Gregory SANCHEZ
+  author: Simon K.
   role_name: pi_hole
   description: An Ansible Role to install Pi-Hole
-  company: chubchubsancho
+  company: simonkeyd
 
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
   license: MIT
 
   min_ansible_version: 2.4
 
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  # github_branch:
-
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
-  #
   platforms:
     - name: Debian
       versions:
@@ -52,13 +24,6 @@ galaxy_info:
 
   galaxy_tags:
     - pihole
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
+    - dns
 
 dependencies: []
-# List your role dependencies here, one per line. Be sure to remove the '[]' above,
-# if you add dependencies to this list.

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,3 +9,13 @@
   tags:
     - pihole
     - configure
+
+- name: configure pi-hole local DNS records
+  template:
+    src: etc/pihole/custom.list.j2
+    dest: /etc/pihole/custom.list
+    mode: 0644
+  when: pi_hole_local_dns_records is defined and pi_hole_local_dns_records | length > 0
+  tags:
+    - pihole
+    - configure

--- a/templates/etc/pihole/custom.list.j2
+++ b/templates/etc/pihole/custom.list.j2
@@ -1,0 +1,3 @@
+{% for local_record in pi_hole_local_dns_records %}
+{{ local_record.ip }} {{ local_record.name }}
+{% endfor %}


### PR DESCRIPTION
Role was lacking a way to configure local DNS recods feature available
in Pi-hole.

This commit adds a new template to configure task that allows role's
consumer to automatically deploy described DNS recods.

This new variable is expecting a list of dict as README explains.