### PR TITLE
allow to checkout specific Pi-hole repository revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An ansible role to install [Pi-Hole](https://pi-hole.net/)
 
 Add `pi-hole` variable for config. These vars can be omited
 
+* `pi_hole_version` - (default: "HEAD") - define branch/tag/commit of `pi-hole` repository which will be cloned
 * `pi_hole_download_dir` - (default: "/home/pihole") - define base directory for clone `pi-hole`
 * `pi_hole_install_dir` - (default: "pi-hole") - define directory where to clone `pi-hole`
 * `pi_hole_query_logging` - (default: true) - define if `pi-hole` will log query

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,3 @@
 ---
+# Revision of Pi-hole repository
+pi_hole_version: "HEAD"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,8 +33,9 @@
   git:
     repo: "{{ pi_hole_repo }}"
     clone: true
+    depth: 20
     dest: "{{ pi_hole_install_dir }}"
-    version: master
+    version: HEAD
   when: pihole_installed.stat.isdir is undefined
   tags:
     - pihole

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,13 +29,13 @@
     - installation
     - prepare
 
-- name: "clone pihole repository"
+- name: "clone pihole repository revision '{{ pi_hole_version }}'"
   git:
     repo: "{{ pi_hole_repo }}"
     clone: true
     depth: 20
     dest: "{{ pi_hole_install_dir }}"
-    version: HEAD
+    version: "{{ pi_hole_version }}"
   when: pihole_installed.stat.isdir is undefined
   tags:
     - pihole


### PR DESCRIPTION
Adds the variable `pi_hole_version`.
This variable defines a specific git repository revision to allow a stable/repeatable installation of Pi-hole.
Defaults to value `master` so current behavior of role is unchanged.

- [x] Successfully tested on a clean Debian 11 installation
- [x] README.md updated