### PR TITLE
 feat(tasks): Add local DNS records support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ Add `pi-hole` variable for config. These vars can be omited
 * `pi_hole_rev_server_cidr` - (default: "") - `pi-hole` reverse cidr
 * `pi_hole_blocking_enabled` - (default: true) - enable `pi-hole` blocking
 
+## Define pi-hole local DNS configuration
+* `pi_hole_local_dns_records` - (default: "") - define `pi-hole` local DNS records. Expects a list of dictionnaries in which each items contains a key `ip` and `name`.
+
+Example:
+```yaml
+vars:
+  pi_hole_local_dns_records:
+    - name: db.lan
+      ip: 10.0.13.37
+    - name: web.lan
+      ip: 10.0.13.38
+```
+
 ## Define pi-hole FTL configuration
 
 Add `pi-hole-FTL` variable config. These vars can be omited

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -9,3 +9,13 @@
   tags:
     - pihole
     - configure
+
+- name: configure pi-hole local DNS records
+  template:
+    src: etc/pihole/custom.list.j2
+    dest: /etc/pihole/custom.list
+    mode: 0644
+  when: pi_hole_local_dns_records is defined and pi_hole_local_dns_records | length > 0
+  tags:
+    - pihole
+    - configure

--- a/templates/etc/pihole/custom.list.j2
+++ b/templates/etc/pihole/custom.list.j2
@@ -1,0 +1,3 @@
+{% for local_record in pi_hole_local_dns_records %}
+{{ local_record.ip }} {{ local_record.name }}
+{% endfor %}


### PR DESCRIPTION
Role was lacking a way to configure local DNS recods feature available
in Pi-hole.

This commit adds a new template to configure task that allows role's
consumer to automatically deploy described DNS recods.

This new variable is expecting a list of dict as README explains.