### PR TITLE
fix(ci): Replace deprecated container image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
           --mount type=bind,source="$(pwd)",target=/tmp/$(basename "$PWD")
           -v /var/run/docker.sock:/var/run/docker.sock
           -w /tmp/$(basename "$PWD")
-          quay.io/ansible/molecule:3.0.8
+          quay.io/ansible/toolset:3.5.0
           molecule lint
     - stage: build
       env: image=debian version=9
@@ -41,7 +41,7 @@ script:
     --mount type=bind,source="$(pwd)",target=/tmp/$(basename "$PWD")
     -v /var/run/docker.sock:/var/run/docker.sock
     -w /tmp/$(basename "$PWD")
-    quay.io/ansible/molecule:3.0.8
+    quay.io/ansible/toolset:3.5.0
     molecule test
 
 notifications:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -11,7 +11,6 @@ lint: |
   set -e
   yamllint -c ./molecule/resources/rules/yamllint.yaml .
   ansible-lint .
-  flake8
 
 platforms:
   - name: "instance"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -8,7 +8,7 @@
     - installation
     - check
 
-- name: "create pihole install directory"
+- name: "create pihole config directory"
   file:
     name: /etc/pihole
     state: directory
@@ -33,7 +33,6 @@
   git:
     repo: "{{ pi_hole_repo }}"
     clone: true
-    depth: 1
     dest: "{{ pi_hole_install_dir }}"
     version: master
   when: pihole_installed.stat.isdir is undefined
@@ -49,3 +48,6 @@
     chdir: "{{ pi_hole_install_dir }}/automated install"
     creates: installed.txt
   when: pihole_installed.stat.isdir is undefined
+  tags:
+    - pihole
+    - installation


### PR DESCRIPTION
Image quay.io/ansible/molecule was marked deprecated and is now
unavailable cf. ansible-community/molecule#3206

This commit replaces this image with recommended quay.io/ansible/toolset
and removes Python flake test as the image does not bundles it and there
is Python code other than molecule pytest tests.

Finally it removes depth parameter on repository clone to ensure that
unattended install can run git commands flawlessly.