### PR TITLE
feat(dhcp): add pi-hole dhcp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ Add `pi-hole` variable for config. These vars can be omited
 * `pi_hole_rev_server_cidr` - (default: "") - `pi-hole` reverse cidr
 * `pi_hole_blocking_enabled` - (default: true) - enable `pi-hole` blocking
 
+## Define pi-hole dhcp configuration
+
+* `pi_hole_dhcp_active` - (default: false) - enable `pi-hole` dhcp server
+* `pi_hole_dhcp_start` - (default: "") - first ip address to hand out
+* `pi_hole_dhcp_end` - (default: "") - last ip address to hand out
+* `pi_hole_dhcp_router` - (default: "") - gateway ip address
+* `pi_hole_dhcp_leasetime` - (default: "24") - dhcp lease time
+* `pi_hole_domain` - (default: "lan") - `pi-hole` domain  name
+* `pi_hole_dhcp_ipv6` - (default: false) - enable IPv6 support
+* `pi_hole_dhcp_rapid_commit` - (default: false) - enable dhcp v4 rapid commit
+
 ## Define pi-hole local DNS configuration
 * `pi_hole_local_dns_records` - (default: "") - define `pi-hole` local DNS records. Expects a list of dictionnaries in which each items contains a key `ip` and `name`.
 

--- a/templates/etc/pihole/setupVars.conf.j2
+++ b/templates/etc/pihole/setupVars.conf.j2
@@ -32,3 +32,13 @@ REV_SERVER_TARGET={{ pi_hole_rev_server_target }}
 {% if pi_hole_rev_server_cidr is defined %}
 REV_SERVER_CIDR={{ pi_hole_rev_server_cidr }}
 {% endif %}
+{% if pi_hole_dhcp_active %}
+DHCP_ACTIVE=true
+DHCP_START={{ pi_hole_dhcp_start }}
+DHCP_END={{ pi_hole_dhcp_end }}
+DHCP_ROUTER={{ pi_hole_dhcp_router }}
+DHCP_LEASETIME={{ pi_hole_dhcp_leasetime | default(24) }}
+PIHOLE_DOMAIN={{ pi_hole_domain | default('lan') }}
+DHCP_IPv6={{ pi_hole_dhcp_ipv6 | default(false) | lower }}
+DHCP_rapid_commit={{ pi_hole_dhcp_rapid_commit | default(false) | lower }}
+{% endif %}


### PR DESCRIPTION
Adds needed variables to enable and configure DHCP support.
Defaults to value `false` so current behavior of role is unchanged.
Default values for other variables are taken from Pi-hole where possible.