### PR TITLE
Restart pi-hole FTL when local DNS records change

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -16,6 +16,8 @@
     dest: /etc/pihole/custom.list
     mode: 0644
   when: pi_hole_local_dns_records is defined and pi_hole_local_dns_records | length > 0
+  notify:
+    - Restart pihole-FTL
   tags:
     - pihole
     - configure


### PR DESCRIPTION
This is to address when local DNS records change. pi-hole FTL should be rebooted for changes to take effect.