### PR TITLE
ci(publish): create import role workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,26 @@
+name: Publish on ansible galaxy
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publis:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v3.0.2
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v4.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Install Ansible.
+        run: pip3 install ansible-core
+
+      - name: Trigger a new import on Galaxy.
+        run: >-
+          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
+          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Environment
         run: |
           python3 -m pip install --upgrade pip
-          python3 -m pip install molecule["docker"] ansible-lint yamllint
+          python3 -m pip install molecule molecule-docker==2.0.0 ansible-lint yamllint
       - name: molecule test
         env:
           image: ${{ matrix.image }}

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,19 +8,17 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.7
+  min_ansible_version: "2.7"
 
   platforms:
     - name: Debian
       versions:
-        - stretch
         - buster
         - bullseye
     - name: Ubuntu
       versions:
-        - bionic
         - focal
-        - impish
+        - jammy
 
   galaxy_tags:
     - pihole

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -17,8 +17,6 @@ platforms:
     image: "$image:$version"
     command: /sbin/init
     privileged: true
-    env:
-      container: docker
     groups:
       - "default"
     tmpfs:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,6 +12,7 @@
   ansible.builtin.file:
     name: /etc/pihole
     state: directory
+    mode: 0644
   when: pihole_installed.stat.isdir is undefined
   tags:
     - pihole
@@ -29,7 +30,7 @@
     - installation
     - prepare
 
-- name: Clone pihole repository revision '{{ pi_hole_version }}'
+- name: Clone pihole repository revision {{ pi_hole_version }}
   ansible.builtin.git:
     repo: "{{ pi_hole_repo }}"
     clone: true


### PR DESCRIPTION
## Why?

Automate role import on `ansible-galaxy` on each release

## How ?

Create github workflow triggered on new release published