### PR TITLE
ci(release-please): use PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,5 +11,6 @@ jobs:
       - name: release-please
         uses: google-github-actions/release-please-action@v3
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           release-type: simple
           command: manifest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,19 @@
 ---
 - name: Install prerequisites
-  include_tasks: "{{ ansible_os_family | lower }}-prerequisites.yml"
+  ansible.builtin.include_tasks: "{{ ansible_os_family | lower }}-prerequisites.yml"
   tags:
     - pihole
     - installation
     - prerequisites
 
 - name: Install pi-hole
-  include_tasks: "install.yml"
+  ansible.builtin.include_tasks: "install.yml"
   tags:
     - pihole
     - installation
 
 - name: Configure pi-hole
-  include_tasks: "configure.yml"
+  ansible.builtin.include_tasks: "configure.yml"
   tags:
     - pihole
     - configure


### PR DESCRIPTION
## Why ?

When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN will not create a new workflow run. This prevents you from accidentally creating recursive workflow runs.

## How ?

Use personal token instead 