### PR TITLE
fix(pihole): use generic service module

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,6 @@
 # handlers file for ansible-pi-hole/
 - name: Restart pihole-FTL
   become: true
-  ansible.builtin.sysvinit:
+  ansible.builtin.service:
     name: pihole-FTL
     state: restarted


### PR DESCRIPTION
When executed on a vm based on [debian-11-generic-amd64-20230124-1270](https://cloud.debian.org/images/cloud/bullseye/20230124-1270/debian-11-generic-amd64-20230124-1270.qcow2) I got the following error:

```sh
TASK [../stacks/pi-hole : Restart pihole-FTL] ************************************************************************
Wednesday 05 April 2023  22:13:35 +0200 (0:00:00.129)       0:00:01.545 ******* 
fatal: [pi-hole]: FAILED! => changed=false 
  msg: 'Could not find the requested service pihole-FTL: '
```

Using [`ansible.builtin.service`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/service_module.html) instead of [`ansible.builtin.sysvinit`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/sysvinit_module.html) fixed it.