### PR TITLE
Allow upgrade

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,20 +1,10 @@
 ---
-- name: Check if pi-hole is already installed
-  ansible.builtin.stat:
-    path: "/opt/pihole"
-  register: pihole_installed
-  tags:
-    - pihole
-    - installation
-    - check
-
 - name: Create pihole config directory
   become: true
   ansible.builtin.file:
     name: /etc/pihole
     state: directory
-    mode: 0644
-  when: pihole_installed.stat.isdir is undefined
+    mode: "0664"
   tags:
     - pihole
     - installation
@@ -22,11 +12,11 @@
 
 - name: Copy pihole setupVars
   become: true
+  register: __pihole_setupVars
   ansible.builtin.template:
     src: etc/pihole/setupVars.conf.j2
     dest: /etc/pihole/setupVars.conf
-    mode: 0644
-  when: pihole_installed.stat.isdir is undefined
+    mode: "0644"
   tags:
     - pihole
     - installation
@@ -34,13 +24,13 @@
 
 - name: Clone pihole repository revision {{ pi_hole_version }}
   become: true
+  register: __pihole_repo
   ansible.builtin.git:
     repo: "{{ pi_hole_repo }}"
     clone: true
     depth: 20
     dest: "{{ pi_hole_install_dir }}"
     version: "{{ pi_hole_version }}"
-  when: pihole_installed.stat.isdir is undefined
   tags:
     - pihole
     - installation
@@ -48,11 +38,13 @@
 
 - name: Install pihole
   become: true
+  when: >-
+    __pihole_setupVars is changed
+    or
+    __pihole_repo is changed
   ansible.builtin.command: bash basic-install.sh --unattended
   args:
     chdir: "{{ pi_hole_install_dir }}/automated install"
-    creates: installed.txt
-  when: pihole_installed.stat.isdir is undefined
   tags:
     - pihole
     - installation

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -4,7 +4,7 @@
   ansible.builtin.file:
     name: /etc/pihole
     state: directory
-    mode: "0664"
+    mode: "0775"
   tags:
     - pihole
     - installation

--- a/templates/etc/pihole/setupVars.conf.j2
+++ b/templates/etc/pihole/setupVars.conf.j2
@@ -13,8 +13,10 @@ IPV4_ADDRESS={{ ansible_default_ipv4.address }}/24
 IPV6_ADDRESS={{ ansible_default_ipv6.address }}
 {% endif %}
 PIHOLE_DNS_1={{ pi_hole_dns_1 | default("8.8.8.8") }}#{{ pi_hole_dns_1_port | default("53") }}
-{% if pi_hole_dns_2 is defined and pi_hole_dns_2_port is defined %}
+{% if pi_hole_dns_2 is defined %}
 PIHOLE_DNS_2={{ pi_hole_dns_2 }}#{{ pi_hole_dns_2_port | default("53") }}
+{% else %}
+PIHOLE_DNS_2=
 {% endif %}
 QUERY_LOGGING={{ pi_hole_query_logging | default(true) | lower }}
 INSTALL_WEB_SERVER={{ pi_hole_install_web_server | default(true) | lower }}


### PR DESCRIPTION
- Write empty DNS2 config into setupVars file if not present. Do so will ensure that the setupVars file is not changed during installation.
- Use the `changed` state from the preparation tasks to decide wether to run installation or not.

Closes #10 